### PR TITLE
Reducing the search bound

### DIFF
--- a/include/rs/builder.h
+++ b/include/rs/builder.h
@@ -137,8 +137,8 @@ class Builder {
     if (curr_num_distinct_keys_ == 2) {
       // Initialize `upper_limit_` and `lower_limit_` using the second CDF
       // point.
-      SetUpperLimit(key, position + max_error_);
-      SetLowerLimit(key, (position < max_error_) ? 0 : position - max_error_);
+      SetUpperLimit(key, position + max_error_ + 1);
+      SetLowerLimit(key, (position < max_error_ + 1) ? 0 : position - max_error_ - 1);
       RememberPreviousCDFPoint(key, position);
       return;
     }
@@ -147,8 +147,8 @@ class Builder {
     const Coord<KeyType>& last = spline_points_.back();
 
     // Compute current `upper_y` and `lower_y`.
-    const double upper_y = position + max_error_;
-    const double lower_y = (position < max_error_) ? 0 : position - max_error_;
+    const double upper_y = position + max_error_ + 1;
+    const double lower_y = (position < max_error_ + 1) ? 0 : position - max_error_ - 1;
 
     // Compute differences.
     assert(upper_limit_.x >= last.x);

--- a/include/rs/radix_spline.h
+++ b/include/rs/radix_spline.h
@@ -53,11 +53,11 @@ class RadixSpline {
   // Returns a search bound [begin, end) around the estimated position.
   SearchBound GetSearchBound(const KeyType key) const {
     const size_t estimate = GetEstimatedPosition(key);
-    const size_t begin = (estimate < max_error_ - 1) ? 0 : (estimate - max_error_ + 1);
+    const size_t begin = (estimate < max_error_) ? 0 : (estimate - max_error_);
     // `end` is exclusive.
-    const size_t end = (estimate + max_error_ + 2 > num_keys_)
+    const size_t end = (estimate + max_error_ + 3 > num_keys_)
                            ? num_keys_
-                           : (estimate + max_error_ + 2);
+                           : (estimate + max_error_ + 3);
     return SearchBound{begin, end};
   }
 

--- a/include/rs/radix_spline.h
+++ b/include/rs/radix_spline.h
@@ -53,7 +53,7 @@ class RadixSpline {
   // Returns a search bound [begin, end) around the estimated position.
   SearchBound GetSearchBound(const KeyType key) const {
     const size_t estimate = GetEstimatedPosition(key);
-    const size_t begin = (estimate < max_error_) ? 0 : (estimate - max_error_);
+    const size_t begin = (estimate < max_error_ - 1) ? 0 : (estimate - max_error_ + 1);
     // `end` is exclusive.
     const size_t end = (estimate + max_error_ + 2 > num_keys_)
                            ? num_keys_


### PR DESCRIPTION
Hello. I've been exploring your repository, and I noticed something interesting about the search range in RadixSpline. The search range is currently defined as [p-e, p+e+2), but it seems that a narrower range, [p-e+1, p+e+2), is sufficient. 

I modified the RadixSpline's GetSearchBound code and ran your test code, and no errors were detected. Additionally, I conducted further tests with various values of 'e', and the results were consistent.

I also observed a similar issue in the PGM-Index, although it's not exactly the same. I would recommend taking a look at the following link for more information: https://github.com/gvinciguerra/PGM-index/issues/43

There are a few potential reasons why this is happening, but it is difficult to pinpoint exactly why the max error differs between training and prediction. If you have any insights on this phenomenon, I would greatly appreciate it if you could share them.

If my observations are correct, I suggest modifying the code to provide a narrower Error Bound. Reducing the search range by even just one could lead to a slight improvement in last mile search performance. I hope you find this suggestion helpful, and I look forward to hearing your thoughts.