### PR TITLE
 Error corridor gradient comparison condition

### DIFF
--- a/include/rs/builder.h
+++ b/include/rs/builder.h
@@ -137,8 +137,8 @@ class Builder {
     if (curr_num_distinct_keys_ == 2) {
       // Initialize `upper_limit_` and `lower_limit_` using the second CDF
       // point.
-      SetUpperLimit(key, position + max_error_ + 1);
-      SetLowerLimit(key, (position < max_error_+ 1) ? 0 : position - max_error_ - 1);
+      SetUpperLimit(key, position + max_error_);
+      SetLowerLimit(key, (position < max_error_) ? 0 : position - max_error_);
       RememberPreviousCDFPoint(key, position);
       return;
     }
@@ -147,8 +147,8 @@ class Builder {
     const Coord<KeyType>& last = spline_points_.back();
 
     // Compute current `upper_y` and `lower_y`.
-    const double upper_y = position + max_error_ + 1;
-    const double lower_y = (position < max_error_ + 1) ? 0 : position - max_error_ - 1;
+    const double upper_y = position + max_error_;
+    const double lower_y = (position < max_error_) ? 0 : position - max_error_;
 
     // Compute differences.
     assert(upper_limit_.x >= last.x);
@@ -171,9 +171,9 @@ class Builder {
 
     // Do we cut the error corridor?
     if ((ComputeOrientation(upper_limit_x_diff, upper_limit_y_diff, x_diff,
-                            y_diff) != Orientation::CW) ||
+                            y_diff) == Orientation::CCW) ||
         (ComputeOrientation(lower_limit_x_diff, lower_limit_y_diff, x_diff,
-                            y_diff) != Orientation::CCW)) {
+                            y_diff) == Orientation::CW)) {
       // Add previous CDF point to spline.
       AddKeyToSpline(prev_point_.x, prev_point_.y);
 

--- a/include/rs/builder.h
+++ b/include/rs/builder.h
@@ -137,8 +137,8 @@ class Builder {
     if (curr_num_distinct_keys_ == 2) {
       // Initialize `upper_limit_` and `lower_limit_` using the second CDF
       // point.
-      SetUpperLimit(key, position + max_error_);
-      SetLowerLimit(key, (position < max_error_) ? 0 : position - max_error_);
+      SetUpperLimit(key, position + max_error_ + 1);
+      SetLowerLimit(key, (position < max_error_+ 1) ? 0 : position - max_error_ - 1);
       RememberPreviousCDFPoint(key, position);
       return;
     }
@@ -147,8 +147,8 @@ class Builder {
     const Coord<KeyType>& last = spline_points_.back();
 
     // Compute current `upper_y` and `lower_y`.
-    const double upper_y = position + max_error_;
-    const double lower_y = (position < max_error_) ? 0 : position - max_error_;
+    const double upper_y = position + max_error_ + 1;
+    const double lower_y = (position < max_error_ + 1) ? 0 : position - max_error_ - 1;
 
     // Compute differences.
     assert(upper_limit_.x >= last.x);

--- a/include/rs/radix_spline.h
+++ b/include/rs/radix_spline.h
@@ -55,9 +55,9 @@ class RadixSpline {
     const size_t estimate = GetEstimatedPosition(key);
     const size_t begin = (estimate < max_error_) ? 0 : (estimate - max_error_);
     // `end` is exclusive.
-    const size_t end = (estimate + max_error_ + 2 > num_keys_)
+    const size_t end = (estimate + max_error_ + 3 > num_keys_)
                            ? num_keys_
-                           : (estimate + max_error_ + 2);
+                           : (estimate + max_error_ + 3);
     return SearchBound{begin, end};
   }
 

--- a/include/rs/radix_spline.h
+++ b/include/rs/radix_spline.h
@@ -55,9 +55,9 @@ class RadixSpline {
     const size_t estimate = GetEstimatedPosition(key);
     const size_t begin = (estimate < max_error_) ? 0 : (estimate - max_error_);
     // `end` is exclusive.
-    const size_t end = (estimate + max_error_ + 3 > num_keys_)
+    const size_t end = (estimate + max_error_ + 2 > num_keys_)
                            ? num_keys_
-                           : (estimate + max_error_ + 3);
+                           : (estimate + max_error_ + 2);
     return SearchBound{begin, end};
   }
 


### PR DESCRIPTION
**Summary**

1. The existing RS, unlike the theory, was learning to guarantee a maximum error of less than e, rather than e or less.
2. The actual search bound of RS is not [p-e, p+e+2), but [p-e+1, p+e+2). Until now, it has been providing a search bound that includes an unnecessary range.
3. I recommend modifying the condition for cutting the error corridor of the GreedySplineCorridor in RS to guarantee a maximum error of e or less, and adjusting the search bound accordingly to [p-e, p+e+3).

**1.  The difference between theory and implementation**
The GreedySplineCorridor implementation in RadixSpline is learning with different criteria compared to the theory. When learning a new spline C in GreedySplineCorridor, the condition for forming a new line segment and storing the existing line segment is as follows:

- Theory: When BC is to the left of BU or to the right of BL
- RS implementation: When BC is not to the right of BU or not to the left of BL
```c++
// Current Implementation
void PossiblyAddKeyToSpline(KeyType key, size_t position) {
    ...
    // Do we cut the error corridor?
    if ((ComputeOrientation(upper_limit_x_diff, upper_limit_y_diff, x_diff,
                            y_diff) != Orientation::CW) ||
        (ComputeOrientation(lower_limit_x_diff, lower_limit_y_diff, x_diff,
                            y_diff) != Orientation::CCW)) {
    ...
```
In other words, even if BC is identical to BU or BL, the learning stops and forms a new line segment for further learning. As a result, the maximum error of less than e is guaranteed, so the search bound for all keys is [p-e+1, p+e+2). Currently, RS is guaranteeing the start of the search bound to be 1 larger than necessary. Note that the search bound for existing keys in the current RS is [p-e+1, p+e+1), while for non-existing keys, it is [p-e+2, p+e+2).

**2. Test Case**
```c++

TYPED_TEST(RadixSplineTest, SingleSegment) {
  using KeyType = typename TestFixture::KeyType;
  const std::vector<KeyType> keys = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; 
  
  // This dataset can guarantee a maximum error of 0 with just a single line segment with a slope of 1.
  const auto rs = CreateRadixSpline(keys, /*max_error*/0);
  
  // Change "rs.spline_points_" into public before runing the test code.
  EXPECT_EQ(rs.spline_points_.size(), 2);
}
```
```
> ./tester
... 
[----------] 1 test from RadixSplineTest/0, where TypeParam = unsigned long
[ RUN      ] RadixSplineTest/0.SingleSegment
/home/mingu/test/RadixSpline/test/radix_spline_test.cc:42: Failure
Expected equality of these values:
  rs.spline_points_.size()
    Which is: 10
  2
 1 FAILED TEST
...
```
In theory, according to the GreedySplineCorridor, a dataset that increases uniformly like the one above can guarantee a maximum error of 0 with a single line segment (2 spline points) with a single slope. However, the test results show that the GreedySplineCorridor implemented in RS is different from the theory: ensures the maximum error is less than e rather than e or less, unlike the theory.

For your information, I attached the actual test code that can be run directly at the end of this post. Before compiling, please change the spline_points_ member variable to public so that you can check the number of splines in the test code.

**3. Code Modification**
```c++
// "rs/include/builder.h"
// To make the implementation identical to the theory, the following modifications should be made:
void PossiblyAddKeyToSpline(KeyType key, size_t position) {
    ...
    // Do we cut the error corridor?
    if ((ComputeOrientation(upper_limit_x_diff, upper_limit_y_diff, x_diff,
                            y_diff) == Orientation::CCW) ||
        (ComputeOrientation(lower_limit_x_diff, lower_limit_y_diff, x_diff,
                            y_diff) == Orientation::CW)) {
    ...
```
Therefore, to implement the GreedySplineCorridor in the same way as the theory, you need to modify the condition for cutting the error corridor in the builder. 

```c++
// "rs/include/radix_spline.h"
// Returns a search bound [begin, end) around the estimated position.
SearchBound GetSearchBound(const KeyType key) const {
  const size_t estimate = GetEstimatedPosition(key);
  const size_t begin = (estimate < max_error_) ? 0 : (estimate - max_error_);
  // `end` is exclusive.
  const size_t end = (estimate + max_error_ + 3 > num_keys_)
                         ? num_keys_
                         : (estimate + max_error_ + 3);
  return SearchBound{begin, end};
}
```
And you also need to modify the search bound provided by the radixspline accordingly. The search bound for existing keys is [p-e, p+e+2), and the search bound for non-existing keys is [p-e+1, p+e+3).

**4. Test Code**
```c++
#include "gtest/gtest.h"
#include "include/rs/builder.h"
#include "include/rs/radix_spline.h"

const size_t kNumRadixBits = 18;
namespace {

// Modified to receive maximum error as a factor and form RS
template <class KeyType>
rs::RadixSpline<KeyType> CreateRadixSpline(const std::vector<KeyType>& keys, size_t error) {
  auto min = std::numeric_limits<KeyType>::min();
  auto max = std::numeric_limits<KeyType>::max();
  if (keys.size() > 0) {
    min = keys.front();
    max = keys.back();
  }
  rs::Builder<KeyType> rsb(min, max, kNumRadixBits, error);
  for (const auto& key : keys) rsb.AddKey(key);
  return rsb.Finalize();
}

// *** Tests ***

template <class T>
struct RadixSplineTest : public testing::Test {
  using KeyType = T;
};

using AllKeyTypes = testing::Types<uint64_t>;
TYPED_TEST_SUITE(RadixSplineTest, AllKeyTypes);

// This case shows that, contrary to theory, RS is implemented to guarantee
// the maximum error less than e, not less than e.
TYPED_TEST(RadixSplineTest, SingleSegment) {
  using KeyType = typename TestFixture::KeyType;
  const std::vector<KeyType> keys = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; 
  
  // This dataset can guarantee a maximum error of 0 with just a single line segment with a slope of 1.
  const auto rs = CreateRadixSpline(keys, /*max_error*/0);
  
  // Change "rs.spline_points_" into public before runing the test code.
  EXPECT_EQ(rs.spline_points_.size(), 2);
}

}  // namespace
```